### PR TITLE
MAST Error

### DIFF
--- a/R/MAST.R
+++ b/R/MAST.R
@@ -68,7 +68,10 @@ MAST <- function(inSCE, condition = NULL, interest.level = NULL,
     SummarizedExperiment::colData(SCENewSample)[, condition] <-
       as.factor(SummarizedExperiment::colData(SCENewSample)[, condition])
   }
-
+  #Check for NAs, if true throw error
+  if (any(is.na(SingleCellExperiment::colData(inSCE)[, condition]))){
+     stop("Data has NAs, use Filter samples by annotation to fix")
+  }
   # >2 levels in the condition
   if (!is.null(interest.level) &
       length(unique(SingleCellExperiment::colData(inSCE)[, condition])) > 2){
@@ -118,7 +121,7 @@ MAST <- function(inSCE, condition = NULL, interest.level = NULL,
                                                     "ci.lo")]
     )
   }
-
+ 
   # Use p-value correction method, here we use fdr
   fcHurdle$fdr <- stats::p.adjust(fcHurdle$"Pr(>Chisq)", "fdr")
 

--- a/R/MAST.R
+++ b/R/MAST.R
@@ -58,6 +58,9 @@ MAST <- function(inSCE, condition = NULL, interest.level = NULL,
   }
 
   # filter based on frequency of expression across samples
+  if (sum(MAST::freq(SCENew) > freqExpressed) <= 1){
+    stop("Not enough genes pass frequency expressed filter of 1")
+  }
   SCENewSample <- SCENew[which(MAST::freq(SCENew) > freqExpressed), ]
 
   # if the condition of interest is numeric, to change it to a factor

--- a/tests/testthat/test-MAST.R
+++ b/tests/testthat/test-MAST.R
@@ -1,5 +1,14 @@
 context("MAST testing")
 
+data(maits, package="MAST")
+maits_sce <- createSCE(assayFile = t(maits$expressionmat),
+                       annotFile = maits$cdat,
+                       featureFile = maits$fdat,
+                       assayName = "logtpm",
+                       inputDataFrames = TRUE,
+                       createLogCounts = FALSE)
+rm(maits)
+
 test_that("MAST should fail if too few samples pass filter", {
   expect_error(MAST(maits_sce, condition = "condition", freqExpressed = "1", useThresh = TRUE, useAssay = "logtpm"),
                "Not enough genes pass frequency expressed filter of 1")

--- a/tests/testthat/test-MAST.R
+++ b/tests/testthat/test-MAST.R
@@ -1,0 +1,7 @@
+context("MAST testing")
+
+test_that("MAST should fail if too few samples pass filter", {
+  expect_error(MAST(maits_sce, condition = "condition", freqExpressed = "1", useThresh = TRUE, useAssay = "logtpm"),
+               "Not enough genes pass frequency expressed filter of 1")
+})
+

--- a/tests/testthat/test-MAST.R
+++ b/tests/testthat/test-MAST.R
@@ -8,9 +8,25 @@ maits_sce <- createSCE(assayFile = t(maits$expressionmat),
                        inputDataFrames = TRUE,
                        createLogCounts = FALSE)
 rm(maits)
+library(scRNAseq)
+
+data(allen, package = "scRNAseq")
+
+tempsce <- as(allen, "SingleCellExperiment")
+
+original <- as(tempsce, "SCtkExperiment")
+
+rm(allen, tempsce)
+assay(original, "counts") <- assay(original, "tophat_counts")
+assay(original, "logcounts") <- log2(assay(original, "counts")+1)
+assay(original, "tophat_counts") <- NULL
 
 test_that("MAST should fail if too few samples pass filter", {
   expect_error(MAST(maits_sce, condition = "condition", freqExpressed = "1", useThresh = TRUE, useAssay = "logtpm"),
                "Not enough genes pass frequency expressed filter of 1")
+})
+test_that("MAST should fail if data has NAs", {
+  expect_error(MAST(original, condition = "Primary.Type", interest.level = "L4 Arf5", freqExpressed = "0.2", useThresh = TRUE, useAssay = "logcounts" ),
+               "Data has NAs, use Filter samples by annotation to fix")
 })
 


### PR DESCRIPTION
Added an error message if the number of genes after filtering was less than or equal to one, as well as a test case. 