### PR TITLE
Change to combinePlot fxn, doublet score capitalization, split UMAP p…

### DIFF
--- a/R/doubletFinder_doubletDetection.R
+++ b/R/doubletFinder_doubletDetection.R
@@ -411,7 +411,7 @@ runDoubletFinder <- function(inSCE,
       output[sceSampleInd, 2] <- result@meta.data$doubletFinderLabel
     }
 
-    colnames(output) <- paste0(colnames(output), "_Resolution_", res)
+    colnames(output) <- paste0(colnames(output), "_resolution_", res)
 
     argsList <- argsList[!names(argsList) %in% ("...")]
     inSCE@metadata$runDoubletFinder <- argsList[-1]

--- a/R/getUMAP.R
+++ b/R/getUMAP.R
@@ -2,11 +2,13 @@
 #' dimension reduction.
 #'
 #' @param inSCE Input \linkS4class{SingleCellExperiment} object.
-#' @param useAssay Indicate which assay to use. The default is "logcounts".
+#' @param useAssay Indicate which assay to use. The default is "counts".
 #' @param sample Character vector. Indicates which sample each cell belongs to.
 #' @param reducedDimName a name to store the results of the dimension reduction
 #' coordinates obtained from this method. This is stored in the SingleCellExperiment
 #' object in the reducedDims slot. Default "UMAP".
+#' @param logNorm Whether the counts will need to be log-normalized prior to
+#' generating the UMAP via scater::logNormCounts. Default TRUE.
 #' @param nNeighbors The size of local neighborhood used for
 #'   manifold approximation. Larger values result in more global
 #'   views of the manifold, while smaller values result in more
@@ -38,14 +40,16 @@
 #' data(scExample, package = "singleCellTK")
 #' sce <- sce[, colData(sce)$type != 'EmptyDroplet']
 #' umap_res <- getUMAP(inSCE = sce, useAssay = "counts",
-#'                     reducedDimName = "UMAP", nNeighbors = 30, alpha = 1,
+#'                     reducedDimName = "UMAP", logNorm = TRUE,
+#'                     nNeighbors = 30, alpha = 1,
 #'                     nIterations = 200, spread = 1, pca = TRUE,
 #'                     initialDims = 50)
 #' reducedDims(umap_res)
 
-getUMAP <- function(inSCE, useAssay = "logcounts",
+getUMAP <- function(inSCE, useAssay = "counts",
                     sample = NULL,
                     reducedDimName = "UMAP",
+                    logNorm = TRUE,
                     nNeighbors = 30,
                     nIterations = 200,
                     alpha = 1,
@@ -71,10 +75,15 @@ getUMAP <- function(inSCE, useAssay = "logcounts",
     samples <- unique(sample)
     umapDims = matrix(nrow = ncol(inSCE), ncol = 2)
     for (i in seq_len(length(samples))){
-        sceSampleInd <- sample == samples[i]
+        useAssayTemp = useAssay
+	sceSampleInd <- sample == samples[i]
         sceSample <- inSCE[, sceSampleInd]
+        if(logNorm){
+	    sceSample <- scater_logNormCounts(sceSample, useAssay = useAssay)
+            useAssayTemp = "ScaterLogNormCounts"            
+        }
 
-        matColData <- SummarizedExperiment::assay(sceSample, useAssay)
+        matColData <- SummarizedExperiment::assay(sceSample, useAssayTemp)
         matColData <- as.matrix(matColData)
 
         if (isTRUE(pca)) {

--- a/R/ggPerQCWrapper.R
+++ b/R/ggPerQCWrapper.R
@@ -180,6 +180,7 @@ plotRunPerCellQCResults <- function(inSCE,
           groupby=groupby,
           violin=violin,
           boxplot=boxplot,
+          summary="median",
           dots=dots,
           transparency=transparency,
           axisSize=axisSize,
@@ -617,12 +618,12 @@ plotDoubletFinderResults <- function(inSCE,
   }
   samples <- unique(sample)
   df.scores <- grep(
-    pattern="doubletFinder_doublet_score_Resolution_",
+    pattern="doubletFinder_doublet_score_resolution_",
     names(colData(inSCE)), value=TRUE
   )
 
   df.labels <- grep(
-    pattern="doubletFinder_doublet_label_Resolution_",
+    pattern="doubletFinder_doublet_label_resolution_",
     names(colData(inSCE)), value=TRUE
   )
   if (length(samples) > 1) {
@@ -644,7 +645,7 @@ plotDoubletFinderResults <- function(inSCE,
         title=paste(
           "DoubletFinder Score Resolution",
           gsub(
-            pattern="doubletFinder_doublet_score_Resolution_",
+            pattern="doubletFinder_doublet_score_resolution_",
             "", x
           )
         ),
@@ -702,7 +703,7 @@ plotDoubletFinderResults <- function(inSCE,
     })
 
     names(scatterScore) <- sapply(df.scores, function(x) {
-      paste0("Scatter_Score_", gsub(
+      paste0("scatter_score_", gsub(
         pattern="doubletFinder_doublet_score_",
         "", x=x
       ))
@@ -766,7 +767,7 @@ plotDoubletFinderResults <- function(inSCE,
     })
 
     names(violinScore) <- sapply(df.scores, function(x) {
-      paste0("Violin_", gsub(
+      paste0("violin_", gsub(
         pattern="doubletFinder_doublet_score_",
         "", x=x
       ))
@@ -800,7 +801,7 @@ plotDoubletFinderResults <- function(inSCE,
         axisSize=axisSize,
         axisLabelSize=axisLabelSize,
         labelClusters=FALSE,
-        legendTitle="Doublet Score",
+        legendTitle="Doublet Label",
         legendSize=legendSize,
         legendTitleSize=legendTitleSize
       )
@@ -915,7 +916,7 @@ plotDoubletCellsResults <- function(inSCE,
   }
 
   if (logScore) {
-    colData(inSCE)$scran_doubletCells_Score <- log10(colData(inSCE)$scran_doubletCells_Score + 1)
+    colData(inSCE)$scran_doubletCells_score <- log10(colData(inSCE)$scran_doubletCells_score + 1)
     titleDoubletCells <- "DoubletCells Doublet Score, log10"
   } else {
     titleDoubletCells <- "DoubletCells Doublet Score"
@@ -925,7 +926,7 @@ plotDoubletCellsResults <- function(inSCE,
   if (length(samples) > 1) {
     merged.plots <- plotSCEViolinColData(
       inSCE=inSCE,
-      coldata="scran_doubletCells_Score",
+      coldata="scran_doubletCells_score",
       groupby=sample,
       xlab="",
       ylab="Doublet Score",
@@ -952,7 +953,7 @@ plotDoubletCellsResults <- function(inSCE,
     scatterScore <- plotSCEDimReduceColData(
       inSCE=inSCESub,
       sample=sampleSub,
-      colorBy="scran_doubletCells_Score",
+      colorBy="scran_doubletCells_score",
       conditionClass="numeric",
       shape=shape,
       reducedDimName=reducedDimName,
@@ -980,7 +981,7 @@ plotDoubletCellsResults <- function(inSCE,
     densityScore <- plotSCEDensityColData(
       inSCE=inSCESub,
       sample=sampleSub,
-      coldata="scran_doubletCells_Score",
+      coldata="scran_doubletCells_score",
       groupby=groupby,
       xlab="Score",
       ylab="Density",
@@ -992,7 +993,7 @@ plotDoubletCellsResults <- function(inSCE,
 
     violinScore <- plotSCEViolinColData(
       inSCE=inSCESub,
-      coldata="scran_doubletCells_Score",
+      coldata="scran_doubletCells_score",
       sample=sampleSub,
       xlab="",
       ylab="Doublet Score",
@@ -1745,25 +1746,6 @@ plotDecontXResults <- function(inSCE,
       titleSize=titleSize
     )
 
-    violinContamination <- plotSCEViolinColData(
-      inSCE=inSCESub,
-      coldata="decontX_contamination",
-      sample=sampleSub,
-      xlab="", ylab="DecontX Contamination",
-      groupby=groupby,
-      violin=violin,
-      boxplot=boxplot,
-      dots=dots,
-      transparency=transparency,
-      title="DecontX Contamination Score",
-      titleSize=titleSize,
-      defaultTheme=defaultTheme,
-      axisSize=axisSize,
-      axisLabelSize=axisLabelSize,
-      dotSize=dotSize,
-      summary="median"
-    )
-
     scatterCluster <- plotSCEDimReduceColData(
       inSCE=inSCESub,
       sample=sampleSub,
@@ -1792,12 +1774,11 @@ plotDecontXResults <- function(inSCE,
 
     res.list <- list(
       scatterDecon, densityContamination,
-      violinContamination, scatterCluster
+      scatterCluster
     )
     names(res.list) <- c(
       "scatterDecon",
       "densityContamination",
-      "violinContamination",
       "scatterCluster"
     )
     return(res.list)

--- a/R/ggPlotting.R
+++ b/R/ggPlotting.R
@@ -2214,11 +2214,21 @@ plotSCEBarAssayData <- function(inSCE,
 }
 
 .ggSCTKCombinePlots <- function(plotlist, ncols = NULL){
-    if(is.null(ncols)){
-        ncols = sqrt(length(plotlist))
-    }
-    return(cowplot::plot_grid(plotlist = plotlist,
-                              ncol = ncols))
+  list.ix = which(lapply(plotlist, class) == "list")
+  if(length(list.ix) > 0){
+    plotlist.sub = plotlist[list.ix]
+    plotlist.sub = do.call(c, plotlist.sub)
+    plotlist.sub = list(cowplot::plot_grid(plotlist = plotlist.sub,
+                                           nrow = length(list.ix)))
+
+    plotlist[list.ix] <- NULL
+    plotlist = c(plotlist, plotlist.sub)
+    ncols = 1
+  }
+
+  if(is.null(ncols)){
+    ncols = round(sqrt(length(plotlist)))
+  }
+  return(cowplot::plot_grid(plotlist = plotlist,
+                            ncol = ncols))
 }
-
-

--- a/R/scran_doubletCells.R
+++ b/R/scran_doubletCells.R
@@ -1,4 +1,4 @@
-.runDoubletCells <- function(cell.matrix = cell.matrix, 
+.runDoubletCells <- function(cell.matrix = cell.matrix,
                               k = k,
                               nIters = nIters,
                               size.factors.norm = NULL,
@@ -9,15 +9,15 @@
                               force.match=FALSE,
                               force.k=20,
                               force.ndist=3,
-                              BNPARAM=BNPARAM, 
-                              BSPARAM=BSPARAM, 
+                              BNPARAM=BNPARAM,
+                              BSPARAM=BSPARAM,
                               BPPARAM=BPPARAM
                               ) {
 
   cell.matrix <- .convertToMatrix(cell.matrix)
 
   scores <- matrix(scran::doubletCells(cell.matrix, k = k,
-                                       niters = nIters, 
+                                       niters = nIters,
                                        size.factors.norm = NULL,
                                        size.factors.content = NULL,
                                        subset.row = NULL,
@@ -26,8 +26,8 @@
                                        force.match=FALSE,
                                        force.k=20,
                                        force.ndist=3,
-                                       BNPARAM=BNPARAM, 
-                                       BSPARAM=BSPARAM, 
+                                       BNPARAM=BNPARAM,
+                                       BSPARAM=BSPARAM,
                                        BPPARAM=BPPARAM
                                        ), ncol=1)
   colnames(scores) <- "scran_doubletCells_score"
@@ -49,28 +49,28 @@
 #' @param simDoublets Number of simulated doublets created for doublet
 #'  detection. Default 10000.
 #' @param seed Seed for the random number generator. Default 12345.
-#' @param size.factors.norm A numeric vector of size factors for normalization 
-#'  of \code{x} prior to PCA and distance calculations. If \code{NULL}, defaults 
-#'  to size factors derived from the library sizes of \code{x}. For the SingleCellExperiment 
+#' @param size.factors.norm A numeric vector of size factors for normalization
+#'  of \code{x} prior to PCA and distance calculations. If \code{NULL}, defaults
+#'  to size factors derived from the library sizes of \code{x}. For the SingleCellExperiment
 #'  method, the default values are taken from \code{\link{sizeFactors}(x)}, if they are available.
-#' @param size.factors.content A numeric vector of size factors for RNA content 
-#'  normalization of \code{x} prior to simulating doublets. #' This is orthogonal to 
+#' @param size.factors.content A numeric vector of size factors for RNA content
+#'  normalization of \code{x} prior to simulating doublets. #' This is orthogonal to
 #'  the values in \code{size.factors.norm}
 #' @param subset.row See \code{?"\link{scran-gene-selection}"}.
-#' @param block An integer scalar controlling the rate of doublet generation, 
+#' @param block An integer scalar controlling the rate of doublet generation,
 #'  to keep memory usage low.
 #' @param d An integer scalar specifying the number of components to retain after the PCA.
-#' @param force.match A logical scalar indicating whether remapping of simulated 
+#' @param force.match A logical scalar indicating whether remapping of simulated
 #'  doublets to original cells should be performed.
-#' @param force.k An integer scalar specifying the number of neighbours to use for 
+#' @param force.k An integer scalar specifying the number of neighbours to use for
 #'  remapping if \code{force.match=TRUE}.
-#' @param force.ndist A numeric scalar specifying the bandwidth for remapping 
+#' @param force.ndist A numeric scalar specifying the bandwidth for remapping
 #'  if \code{force.match=TRUE}.
 #' @param BNPARAM A \code{\link[BiocNeighbors]{BiocNeighborParam}} object specifying the nearest neighbor algorithm.
 #' This should be an algorithm supported by \code{\link[BiocNeighbors]{findNeighbors}}.
-#' @param BSPARAM A \code{\link[BiocSingular]{BiocSingularParam}} object specifying the algorithm to 
+#' @param BSPARAM A \code{\link[BiocSingular]{BiocSingularParam}} object specifying the algorithm to
 #'  use for PCA, if \code{d} is not \code{NA}.
-#' @param BPPARAM A \code{\link[BiocParallel]{BiocParallelParam}} object specifying whether the 
+#' @param BPPARAM A \code{\link[BiocParallel]{BiocParallelParam}} object specifying whether the
 #'  neighbour searches should be parallelized.
 #' @details This function is a wrapper function for \link[scran]{doubletCells}.
 #'  \code{runDoubletCells} runs \link[scran]{doubletCells} for each
@@ -104,8 +104,8 @@ runDoubletCells <- function(inSCE,
     force.match=FALSE,
     force.k=20,
     force.ndist=3,
-    BNPARAM=BiocNeighbors::KmknnParam(), 
-    BSPARAM=BiocSingular::bsparam(), 
+    BNPARAM=BiocNeighbors::KmknnParam(),
+    BSPARAM=BiocSingular::bsparam(),
     BPPARAM=BiocParallel::SerialParam()
 ) {
   #argsList <- as.list(formals(fun = sys.function(sys.parent()), envir = parent.frame()))
@@ -123,7 +123,7 @@ runDoubletCells <- function(inSCE,
 
   ## Define result matrix for all samples
   output <- S4Vectors::DataFrame(row.names = colnames(inSCE),
-            scran_doubletCells_Score = numeric(ncol(inSCE)))
+            scran_doubletCells_score = numeric(ncol(inSCE)))
 
   ## Loop through each sample and run barcodeRank
   samples <- unique(sample)
@@ -134,7 +134,7 @@ runDoubletCells <- function(inSCE,
     mat <- SummarizedExperiment::assay(sceSample, i = useAssay)
 
     result <- withr::with_seed(seed,
-              .runDoubletCells(cell.matrix = mat, 
+              .runDoubletCells(cell.matrix = mat,
                                k = nNeighbors,
                                nIters = simDoublets,
                                size.factors.norm = NULL,
@@ -145,8 +145,8 @@ runDoubletCells <- function(inSCE,
                                force.match=FALSE,
                                force.k=20,
                                force.ndist=3,
-                               BNPARAM=BNPARAM, 
-                               BSPARAM=BSPARAM, 
+                               BNPARAM=BNPARAM,
+                               BSPARAM=BSPARAM,
                                BPPARAM=BPPARAM
                                ))
 

--- a/man/getUMAP.Rd
+++ b/man/getUMAP.Rd
@@ -7,9 +7,10 @@ dimension reduction.}
 \usage{
 getUMAP(
   inSCE,
-  useAssay = "logcounts",
+  useAssay = "counts",
   sample = NULL,
   reducedDimName = "UMAP",
+  logNorm = TRUE,
   nNeighbors = 30,
   nIterations = 200,
   alpha = 1,
@@ -22,13 +23,16 @@ getUMAP(
 \arguments{
 \item{inSCE}{Input \linkS4class{SingleCellExperiment} object.}
 
-\item{useAssay}{Indicate which assay to use. The default is "logcounts".}
+\item{useAssay}{Indicate which assay to use. The default is "counts".}
 
 \item{sample}{Character vector. Indicates which sample each cell belongs to.}
 
 \item{reducedDimName}{a name to store the results of the dimension reduction
 coordinates obtained from this method. This is stored in the SingleCellExperiment
 object in the reducedDims slot. Default "UMAP".}
+
+\item{logNorm}{Whether the counts will need to be log-normalized prior to
+generating the UMAP via scater::logNormCounts. Default TRUE.}
 
 \item{nNeighbors}{The size of local neighborhood used for
 manifold approximation. Larger values result in more global
@@ -71,7 +75,8 @@ dimension reduction.
 data(scExample, package = "singleCellTK")
 sce <- sce[, colData(sce)$type != 'EmptyDroplet']
 umap_res <- getUMAP(inSCE = sce, useAssay = "counts",
-                    reducedDimName = "UMAP", nNeighbors = 30, alpha = 1,
+                    reducedDimName = "UMAP", logNorm = TRUE,
+                    nNeighbors = 30, alpha = 1,
                     nIterations = 200, spread = 1, pca = TRUE,
                     initialDims = 50)
 reducedDims(umap_res)

--- a/man/runDoubletCells.Rd
+++ b/man/runDoubletCells.Rd
@@ -40,38 +40,38 @@ detection. Default 10000.}
 
 \item{seed}{Seed for the random number generator. Default 12345.}
 
-\item{size.factors.norm}{A numeric vector of size factors for normalization 
-of \code{x} prior to PCA and distance calculations. If \code{NULL}, defaults 
-to size factors derived from the library sizes of \code{x}. For the SingleCellExperiment 
+\item{size.factors.norm}{A numeric vector of size factors for normalization
+of \code{x} prior to PCA and distance calculations. If \code{NULL}, defaults
+to size factors derived from the library sizes of \code{x}. For the SingleCellExperiment
 method, the default values are taken from \code{\link{sizeFactors}(x)}, if they are available.}
 
-\item{size.factors.content}{A numeric vector of size factors for RNA content 
-normalization of \code{x} prior to simulating doublets. #' This is orthogonal to 
+\item{size.factors.content}{A numeric vector of size factors for RNA content
+normalization of \code{x} prior to simulating doublets. #' This is orthogonal to
 the values in \code{size.factors.norm}}
 
 \item{subset.row}{See \code{?"\link{scran-gene-selection}"}.}
 
-\item{block}{An integer scalar controlling the rate of doublet generation, 
+\item{block}{An integer scalar controlling the rate of doublet generation,
 to keep memory usage low.}
 
 \item{d}{An integer scalar specifying the number of components to retain after the PCA.}
 
-\item{force.match}{A logical scalar indicating whether remapping of simulated 
+\item{force.match}{A logical scalar indicating whether remapping of simulated
 doublets to original cells should be performed.}
 
-\item{force.k}{An integer scalar specifying the number of neighbours to use for 
+\item{force.k}{An integer scalar specifying the number of neighbours to use for
 remapping if \code{force.match=TRUE}.}
 
-\item{force.ndist}{A numeric scalar specifying the bandwidth for remapping 
+\item{force.ndist}{A numeric scalar specifying the bandwidth for remapping
 if \code{force.match=TRUE}.}
 
 \item{BNPARAM}{A \code{\link[BiocNeighbors]{BiocNeighborParam}} object specifying the nearest neighbor algorithm.
 This should be an algorithm supported by \code{\link[BiocNeighbors]{findNeighbors}}.}
 
-\item{BSPARAM}{A \code{\link[BiocSingular]{BiocSingularParam}} object specifying the algorithm to 
+\item{BSPARAM}{A \code{\link[BiocSingular]{BiocSingularParam}} object specifying the algorithm to
 use for PCA, if \code{d} is not \code{NA}.}
 
-\item{BPPARAM}{A \code{\link[BiocParallel]{BiocParallelParam}} object specifying whether the 
+\item{BPPARAM}{A \code{\link[BiocParallel]{BiocParallelParam}} object specifying whether the
 neighbour searches should be parallelized.}
 }
 \value{

--- a/man/runScrublet.Rd
+++ b/man/runScrublet.Rd
@@ -109,7 +109,7 @@ reduction, unless \code{meanCenter} is \code{TRUE}. Default \code{TRUE}.}
 the transcriptomes prior to k-nearest-neighbor graph construction.
 Default 30.}
 
-\item{tsneAngle}{Float. Determines angular size of a distant node as measured 
+\item{tsneAngle}{Float. Determines angular size of a distant node as measured
 from a point in the t-SNE plot. If default, it is set to 0.5 Default \code{NULL}.}
 
 \item{tsnePerplexity}{Integer. The number of nearest neighbors that

--- a/tests/testthat/test-qc.R
+++ b/tests/testthat/test-qc.R
@@ -28,24 +28,18 @@ test_that("Testing emptydrops",{
 })
 
 
-test_that(desc = "Testing scran", {
-  sce <- runDoubletCells(sce)
-  expect_equal(length(colData(sce)$scran_doubletCells_Score),ncol(sce))
-  expect_equal(class(colData(sce)$scran_doubletCells_Score), "numeric")
-}) 
-
 test_that(desc = "Testing DoubletFinder",  {
   sce <- runDoubletFinder(sce, seuratPcs = 1:3, seuratNfeatures = 300, seuratRes = 1,
 	 verbose = FALSE, seed = 12345)
-  expect_equal(length(colData(sce)$doubletFinder_doublet_score_Resolution_1),ncol(sce))
-  expect_equal(class(colData(sce)$doubletFinder_doublet_score_Resolution_1), "numeric")
+  expect_equal(length(colData(sce)$doubletFinder_doublet_score_resolution_1),ncol(sce))
+  expect_equal(class(colData(sce)$doubletFinder_doublet_score_resolution_1), "numeric")
 })
 
 
 test_that(desc = "Testing runDoubletCells", {
   sceres <- runDoubletCells(sce)
-  expect_equal(length(colData(sceres)$scran_doubletCells_Score),ncol(sce))
-  expect_equal(class(colData(sceres)$scran_doubletCells_Score), "numeric")
+  expect_equal(length(colData(sceres)$scran_doubletCells_score),ncol(sce))
+  expect_equal(class(colData(sceres)$scran_doubletCells_score), "numeric")
 })
 
 test_that("Testing scrublet",{

--- a/tests/testthat/test-visualization.R
+++ b/tests/testthat/test-visualization.R
@@ -2,9 +2,9 @@
 library(singleCellTK)
 context("Testing dimensionality reduction algorithms")
 data(scExample, package = "singleCellTK")
-sce@assays@data$logcounts=log10(sce@assays@data$counts + 1)
-sceres <- getUMAP(inSCE = sce, useAssay = "logcounts", sample = NULL, nNeighbors = 30, reducedDimName = "UMAP",
-                nIterations = 20, alpha = 1, minDist = 0.01, pca = TRUE, initialDims = 50)
+sce <- sce[, colData(sce)$type != 'EmptyDroplet']
+sceres <- getUMAP(inSCE = sce, useAssay = "counts", logNorm = TRUE, sample = NULL, nNeighbors = 10, reducedDimName = "UMAP",
+                nIterations = 20, alpha = 1, minDist = 0.01, pca = TRUE, initialDims = 20)
 
 test_that(desc = "Testing getUMAP", {
         expect_equal(names(reducedDims(sceres)), "UMAP")
@@ -45,7 +45,7 @@ test_that(desc = "Testing plotResults functions", {
   sceres <- runCellQC(sceres, algorithms = c("QCMetrics", "cxds", "bcds", "cxds_bcds_hybrid",
                                              "scrublet", "doubletFinder", "decontX"))
   sceres <- runDoubletCells(sceres, size.factors.norm = rep(1, ncol(sceres)))
-  
+
   r1 <- plotRunPerCellQCResults(inSCE = sceres)
     expect_is(r1, "list")
   r2 <- plotScrubletResults(inSCE = sceres, reducedDimName="UMAP")


### PR DESCRIPTION
1. The .ggSCTKCombinePlots function has been debugged to accept list of lists of plots, generated from having multiple samples in a dataset, and to fix the " Viewport has zero dimension(s)" bug.
2. The UMAP/TSNE in runScrublet now runs per-sample.
3. getUMAP now incorporates the scater_logNormCounts function.
4. Appropriate edits to test units
5. doubletFinder/doubletCells outputs have been renamed to follow the correct nomenclature.