### PR TITLE
Updates for SoupX

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -82,7 +82,11 @@ jobs:
           _R_CHECK_CRAN_INCOMING_: false
         run: |
           options(crayon.enabled = TRUE)
-          reticulate::use_python(system('which python', intern=TRUE)) 
+          if (Sys.info()[1] == "Windows") {
+            reticulate::use_python(system('where python', intern=TRUE))
+          } else {
+            reticulate::use_python(system('which python', intern=TRUE))
+          }
           reticulate::py_config()
           rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
         shell: Rscript {0}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -63,6 +63,10 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      - name: Install fftw3 on Linux
+        if: runner.os == 'Linux'
+        run: sudo apt-get install libfftw3-dev
+
       - uses: r-lib/actions/setup-r-dependencies@v1
         with:
           extra-packages: rcmdcheck
@@ -83,7 +87,7 @@ jobs:
         run: |
           options(crayon.enabled = TRUE)
           if (Sys.info()[1] == "Windows") {
-            reticulate::use_python(system('where python', intern=TRUE))
+            reticulate::use_python(system('where python', intern=TRUE)[1])
           } else {
             reticulate::use_python(system('which python', intern=TRUE))
           }

--- a/inst/shiny/helpers.R
+++ b/inst/shiny/helpers.R
@@ -286,8 +286,11 @@ combineQCSubPlots <- function(output, combineP, algo, sampleList, plots, plotIds
   } else {
     tabsetID <- paste0(algo, "Tabs") # for the tabsetPanel within a tab
     mainPlotID <- paste0(plotIds[[algo]], "Main")
-    output[[plotIds[[algo]]]] <- renderUI(plotOutput(mainPlotID))
-    output[[mainPlotID]] <- renderPlot(plots$Violin)
+    if (!is.null(plots$Violin)) {
+      output[[plotIds[[algo]]]] <- renderUI(plotOutput(mainPlotID))
+      output[[mainPlotID]] <- renderPlot(plots$Violin)
+    }
+    
 
     for (i in seq_along(sampleList)) {
       local({
@@ -354,6 +357,9 @@ arrangeQCPlots <- function(inSCE, input, output, algoList, sampleList, plotIDs, 
       dxPlots <- plotDecontXResults(inSCE, combinePlot = combineP, sample = sampleList,
                                     reducedDimName = redDimName)
       combineQCSubPlots(output, combineP, a, uniqueSampleNames, dxPlots, plotIDs, statuses)
+    } else if (a == "soupX") {
+      soupXPlots <- plotSoupXResult(inSCE, combinePlot = combineP)
+      combineQCSubPlots(output, combineP, a, uniqueSampleNames, soupXPlots, plotIDs, statuses)
     } else if (a == "QCMetrics") {
       qcmPlots <- plotRunPerCellQCResults(inSCE, sample = sampleList, combinePlot = combineP)
       combineQCMPlots(input, output, combineP, uniqueSampleNames, qcmPlots, plotIDs, statuses)

--- a/inst/shiny/qc_help_pages/ui_soupX_help.R
+++ b/inst/shiny/qc_help_pages/ui_soupX_help.R
@@ -1,0 +1,113 @@
+soupXHelpModal <- function() {
+    modalDialog(
+        tags$style(HTML("
+      div {
+        word-wrap: break-word;
+      }
+      ")),
+        tags$div(
+            h3("SoupX Parameters"),
+            fluidRow(
+                column(4, tags$b("Parameter Name")),
+                column(8, tags$b("Description"))
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "cluster"),
+                column(8, "Prior knowledge of clustering labels on cells. Can 
+                       be specified with preloaded cell annotations. When not 
+                       supplied, scran::quickCluster method will be applied.")
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "tfidfMin"),
+                column(8, "Minimum value of tfidf to accept for a marker gene. 
+                       Default 1. Parameter for SoupX::autoEstCont()")
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "soupQuantile"),
+                column(8, "Only use genes that are at or above this expression 
+                       quantile in the soup. This prevents inaccurate estimates 
+                       due to using genes with poorly constrained contribution 
+                       to the background. Default 0.9. Parameter for 
+                       SoupX::autoEstCont()")
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "maxMarkers"),
+                column(8, "If we have heaps of good markers, keep only the best 
+                       maxMarkers of them. Default 100. Parameter for 
+                       SoupX::autoEstCont()")
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "contaminationRange"),
+                column(8, "This constrains the contamination fraction to lie 
+                       within this range. Must be between 0 and 1. The high end 
+                       of this range is passed to 
+                       SoupX::estimateNonExpressingCells as 
+                       `maximumContamination`. Use 'Lower range' and 'Higher 
+                       range' for the two values. Default 0.01 - 0.8. Parameter 
+                       for SoupX::autoEstCont()")
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "rhoMaxFDR"),
+                column(8, "Integer. False discovery rate passed to 
+                       SoupX::estimateNonExpressingCells, to test if rho is 
+                       less than `maximumContamination`. Default 0.2. Parameter 
+                       for SoupX::autoEstCont()")
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "priorRho"),
+                column(8, "Mode of gamma distribution prior on contamination 
+                       fraction. Default 0.05. Parameter for 
+                       SoupX::autoEstCont()")
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "priorRhoStdDev"),
+                column(8, "Standard deviation of gamma distribution prior on 
+                       contamination fraction. Default 0.1. Parameter for 
+                       SoupX::autoEstCont()")
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "forceAccept"),
+                column(8, "Should we allow very high contamination fractions to 
+                       be used. Default FALSE (not checked). Parameter for 
+                       SoupX::autoEstCont()")
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "adjustMethod"),
+                column(8, "Method to use for correction. One of 'subtraction', 
+                       'soupOnly', or 'multinomial'. Default 'subtraction'. 
+                       Parameter for SoupX::adjustCounts")
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "roundToInt"),
+                column(8, "Should the resulting matrix be rounded to integers? 
+                       Default FALSE (not checked). Parameter for 
+                       SoupX::adjustCounts")
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "tol"),
+                column(8, "Allowed deviation from expected number of soup 
+                       counts. Don't change this. Default 0.001. Parameter for 
+                       SoupX::adjustCounts")
+            ),
+            tags$hr(),
+            fluidRow(
+                column(4, "pCut"),
+                column(8, "The p-value cut-off used when method = 'soupOnly'. 
+                       Default 0.01. Parameter for SoupX::adjustCounts")
+            )
+        )
+    )
+}
+

--- a/inst/shiny/ui_02_qc.R
+++ b/inst/shiny/ui_02_qc.R
@@ -50,6 +50,30 @@ shinyPanelQC <- fluidPage(
                      checkboxInput("DXverbose", "verbose - Print log messages?", value = TRUE), # T/F input
             )
           ),
+          checkboxInput("soupX", "SoupX"),
+          shinyjs::hidden(
+            tags$style(HTML("#soupXParams {margin-left:40px}")),
+            tags$div(id = "soupXParams",
+                     actionLink("SoupXhelp", "Help", icon = icon("info-circle")),
+                     tags$hr(),
+                     selectInput("soupXCluster", "cluster - Prior knowledge of clustering labels on cells (default None)", list()),
+                     numericInput("soupXTfidfMin", "tfidfMin - Minimum value of tfidf to accept for a marker gene (default 1)", 1),
+                     numericInput("soupXQuantile", "soupQuantile - Only use genes that are at or above this expression quantile in the soup (default 0.9)", 0.9, min = 0, max = 1),
+                     numericInput("soupXMaxMarkers", "maxMarkers - If we have heaps of good markers, keep only the best maxMarkers of them. (Default 100)", 100, min = 1),
+                     p("contaminationRange - This constrains the contamination fraction to lie within this range. (default 0.01 - 0.8)"),
+                     numericInput("soupXContRangeLow", "Lower range:", 0.01, min = 0, max = 1),
+                     numericInput("soupXContRangeHigh", "Higher range:", 0.8, min = 0, max = 1),
+                     numericInput("soupXRhoMaxFDR", "rhoMaxFDR - FDR passed to SoupX::estimateNonExpressingCells, to test if rho is less than maximumContamination (default 0.2)", 0.2, min = 0, max = 1),
+                     numericInput("soupXPriorRho", "priorRho - Mode of gamma distribution prior on contamination fraction (default 0.05)", 0.05, 0, 1),
+                     numericInput("soupXPriorRhoStdDev", "priorRhoStdDev - Standard deviation of gamma distribution prior on contamination fraction (default 0.1)", 0.1),
+                     checkboxInput("soupXForceAccept", "forceAccept - Should we allow very high contamination fractions to be used?", FALSE),
+                     selectInput("soupXAdjustMethod", "AdjustMethod - Method to use for correction (default 'subtraction')",
+                                 choices = c('subtraction', 'soupOnly', 'multinomial'), selected = "subtraction"),
+                     checkboxInput("soupXRoundToInt", "roundToInt - Should the resulting matrix be rounded to integers?", FALSE),
+                     numericInput("soupXTol", "tol - Allowed deviation from expected number of soup counts (default 0.001)", 0.001),
+                     numericInput("soupXPCut", "pCut - The p-value cut-off used when method = 'soupOnly' (default 0.01)", 0.01, 0, 1)
+            )
+          ),
           tags$hr(),
           h4("Doublet Detection"),
           # scDblFinder

--- a/man/plotSoupXResult.Rd
+++ b/man/plotSoupXResult.Rd
@@ -6,12 +6,13 @@
 \usage{
 plotSoupXResult(
   inSCE,
-  sampleID = NULL,
+  sample = NULL,
   background = FALSE,
   reducedDimName = NULL,
   plotNCols = 3,
   plotNRows = 2,
   baseSize = 8,
+  combinePlot = c("all", "sample", "none"),
   xlab = NULL,
   ylab = NULL,
   dim1 = NULL,
@@ -32,8 +33,8 @@ plotSoupXResult(
 \item{inSCE}{A \linkS4class{SingleCellExperiment} object. With 
 \code{\link{runSoupX}} already applied.}
 
-\item{sampleID}{Character vector. The samples that should be included in the
-figure. Leave this \code{NULL} for all samples. Default \code{NULL}.}
+\item{sample}{Character vector. Indicates which sample each cell belongs to. 
+Default \code{NULL}.}
 
 \item{background}{Logical. Whether \code{background} was applied when 
 running \code{\link{runSoupX}}. Default \code{FALSE}.}
@@ -53,6 +54,11 @@ Default \code{2}.}
 \item{baseSize}{Numeric. The base font size for all text. Default 12. Can be 
 overwritten by titleSize, axisSize, and axisLabelSize, legendSize, 
 legendTitleSize. Default \code{8}.}
+
+\item{combinePlot}{Must be either \code{"all"}, \code{"sample"}, or 
+\code{"none"}. \code{"all"} will combine all plots into a single 
+\code{.ggplot} object, while \code{"sample"} will output a list of plots 
+separated by sample. Default \code{"all"}.}
 
 \item{xlab}{Character vector. Label for x-axis. Default \code{NULL}.}
 

--- a/man/runSoupX.Rd
+++ b/man/runSoupX.Rd
@@ -61,8 +61,7 @@ Default \code{"SoupX"} when not using a background, otherwise,
 \item{cluster}{Prior knowledge of clustering labels on cells. A single 
 character string for specifying clustering label stored in 
 \code{colData(inSCE)}, or a character vector with as many elements as cells.
-When not supplied, SCTK default clustering method will be applied (see 
-\href{https://camplab.net/sctk/v2.4.1/articles/articles/console_analysis_tutorial.html#normalization}{detail}).}
+When not supplied, \code{\link[scran]{quickCluster}} method will be applied.}
 
 \item{reducedDimName}{A single character string of the prefix of output 
 corrected embedding matrix for each sample. Default \code{"SoupX_UMAP_"} when 


### PR DESCRIPTION
UI added
Note that I made a minor change to `inst/shiny/helpers.R"` for `combineQCSubPlots()`. Now it will insert the main plot UI only when `$Violin` appears in `plotList`. Did this because SoupX plots do not include any. Otherwise there will be a big blank region for the "main Violin plot"